### PR TITLE
Fixed long loadtime of pd.load_fwf

### DIFF
--- a/notebooks/api/02f_pds.utils.ipynb
+++ b/notebooks/api/02f_pds.utils.ipynb
@@ -46,7 +46,7 @@
     "import pandas as pd\n",
     "import pvl\n",
     "from fastcore.utils import Path\n",
-    "from planetarypy import utils"
+    "from planetarypy.pds import utils"
    ]
   },
   {
@@ -150,7 +150,7 @@
     "    this reader should work for all PDS TAB files.\n",
     "    \"\"\"\n",
     "    indexpath = Path(indexpath)\n",
-    "    df = pd.read_fwf(indexpath, header=None, names=label.colnames, colspecs=label.colspecs)\n",
+    "    df = pd.read_csv(indexpath,header=None,names=label.colnames,)\n",
     "    if convert_times:\n",
     "        for column in [col for col in df.columns if \"TIME\" in col]:\n",
     "            if column in [\"LOCAL_TIME\", \"DWELL_TIME\"]:\n",

--- a/notebooks/api/02f_pds.utils.ipynb
+++ b/notebooks/api/02f_pds.utils.ipynb
@@ -46,7 +46,7 @@
     "import pandas as pd\n",
     "import pvl\n",
     "from fastcore.utils import Path\n",
-    "from planetarypy.pds import utils"
+    "from planetarypy import utils"
    ]
   },
   {

--- a/planetarypy/pds/utils.py
+++ b/planetarypy/pds/utils.py
@@ -100,7 +100,7 @@ def index_to_df(
     this reader should work for all PDS TAB files.
     """
     indexpath = Path(indexpath)
-    df = pd.read_fwf(indexpath, header=None, names=label.colnames, colspecs=label.colspecs)
+    df = pd.read_csv(indexpath,header=None,names=label.colnames,)
     if convert_times:
         for column in [col for col in df.columns if "TIME" in col]:
             if column in ["LOCAL_TIME", "DWELL_TIME"]:


### PR DESCRIPTION
This should fix the incredibly long loadtime by load_fwf from pandas which is caused by the pure python backend. read_csv has a C backend and therefore reads much faster.

Example: RDRCUMINDEX.LBL took 60 minutes to read now only takes 1 minute to read.